### PR TITLE
Add Chinese quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,193 @@
 # MOE-QGEN
+
+Automation utilities for reproducing MOE-enhanced DUQGEN experiments on remote
+servers. The toolkit mirrors the DUQGEN directory layout, submits jobs through
+the cluster `submit` wrapper, and gathers everything required for the final
+report—including baseline results, ablations A1–A5, and visual analytics.
+
+## Key capabilities
+
+- 🔁 **One command for all experiments** – run the full DUQGEN suite (baseline +
+  A1–A5) across FiQA, BEIR, and NQ datasets by entering the server password
+  once.
+- 🧠 **Head-node aware orchestration** – automatically wraps every generation
+  and evaluation job with the university `submit` tool, polls `squeue/sacct`,
+  and enforces the DUQGEN repository layout on the compute nodes.
+- 📦 **Asset bootstrapping** – optional bootstrap commands pre-download
+  LLaMA-2, Contriever, ColBERTv2, and BEIR collections so the generation step is
+  fully offline.
+- 📊 **Complete reporting** – collects `/usr/bin/time` statistics, uniqueness,
+  coverage, nDCG@10/MAP/MRR, expert-weight and cluster heatmaps, and writes a
+  Markdown/CSV experiment table ready for the paper.
+- 🛠️ **Fail-fast debugging** – job stdout/stderr, weight histories, and cluster
+  metadata are mirrored locally for each dataset/experiment pair.
+
+## Installation
+
+Create a Python ≥3.9 environment on your workstation (or Codespace) and install
+local dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+These packages are only needed for the automation client (SSH + plotting). The
+remote DUQGEN environment keeps using its own Conda setup.
+
+## Server configuration
+
+All remote settings live in `configs/duqgen_moe.yaml`.
+
+### `env.workdir`
+Absolute path to the DUQGEN repository on the server. The automation always
+changes into this directory before executing commands so that the DUQGEN folder
+structure remains untouched.
+
+### `env.setup`
+Shell commands executed at the start of every job (e.g. sourcing your
+`~/.bashrc` and activating the `duqgen` Conda environment).
+
+### `env.bootstrap`
+Commands that should run **once** before the experiment sweep. They execute via
+`submit` to respect the head-node restriction and typically:
+
+- install DUQGEN requirements,
+- download LLaMA-2/Contriever/ColBERT weights with `huggingface-cli`,
+- pull BEIR datasets (example Python one-liner provided),
+- prepare retrieval runs used by DUQGEN evaluation.
+
+Placeholders like `{workdir}` are expanded automatically.
+
+### `env.submit`
+Parameters for the HPC job wrapper. The defaults match the H100 Head Unit
+manual:
+
+- `binary`: command name (`submit`).
+- `env`: Conda environment passed to `-env`.
+- `job_dir`: directory under the DUQGEN tree that stores job scripts/logs.
+- `poll_interval`: seconds between `squeue` checks.
+- `extra_args`: additional flags such as `-p gpu-test` if you need a specific
+  partition.
+
+### `datasets`
+Absolute paths to the DUQGEN collections/embeddings/runs. The sample file lists
+FiQA, NQ, and the BEIR datasets used in the paper—replace `<user>` with your
+account name.
+
+### `experiments`
+Each block represents one run (baseline or ablation). Command templates can use
+any field from the dataset, experiment params, or `output_dir`/`output_dir_rel`
+(which points to `runs/<dataset>/<experiment>` inside `env.workdir`). The
+provided definitions cover:
+
+- A1 – automatic K (full vs. subsampling).
+- A2 – expert removal (neighbour, TF-IDF, novelty, cluster).
+- A3 – reward scheduling (r1, r1+r2, r1+r2+r3).
+- A4 – anti-collapse safeguards.
+- A5 – multi-candidate sampling vs. deduplication.
+
+## Running everything in one step
+
+From your local machine or Codespace:
+
+```bash
+python scripts/run_remote_experiments.py \
+  --config configs/duqgen_moe.yaml \
+  --host <login_node_ip> \
+  --user <username> \
+  --password <password>
+```
+
+What happens next:
+
+1. The script connects via SSH and, if configured, kicks off the bootstrap job
+   to download models/datasets.
+2. For each dataset/experiment it creates a job script under
+   `<workdir>/runtime/moe_jobs`, submits it with `submit`, and monitors
+   completion with `squeue`/`sacct`.
+3. `/usr/bin/time -v` metrics land in `<output_dir>/<job>.time`; stdout/stderr
+   are saved alongside the job logs for post-mortem analysis.
+4. Generated queries, weight trajectories, cluster stats, evaluation metrics,
+   and job logs are downloaded to `./artifacts/<dataset>/<experiment>/`.
+5. Expert-weight and cluster heatmaps are rendered locally and stored with the
+   artifacts.
+6. Once all jobs finish, the per-run metrics are merged into
+   `artifacts/summary.csv` and `artifacts/summary.md`.
+
+If any job fails (non-zero exit or `sacct` reports a non-`COMPLETED` state) the
+pipeline stops immediately and surfaces the offending stdout/stderr.
+
+## Output layout
+
+```
+artifacts/
+  ├── fiqa/
+  │   └── moe_full/
+  │       ├── generated_queries.jsonl
+  │       ├── weights_history.jsonl
+  │       ├── weights_heatmap.png
+  │       ├── cluster_stats.json
+  │       ├── cluster_heatmap.png
+  │       ├── <job>.out / <job>.err / <job>.time
+  │       └── metrics.json
+  ├── ... other datasets / experiments ...
+  ├── summary.csv
+  └── summary.md
+```
+
+The CSV/Markdown table includes K-selection time & memory, average r1,
+uniqueness, coverage, nDCG@10, MAP, and MRR—matching the DUQGEN reporting
+requirements.
+
+## Tips
+
+- Ensure `/usr/bin/time` is available on compute nodes. Adjust the command in
+  the configuration if it lives elsewhere.
+- The bootstrap commands may require additional Python packages on the remote
+  side (`huggingface_hub`, `beir`, etc.). Install them inside the DUQGEN Conda
+  environment referenced by `env.setup`.
+- Use `submit` utilities (`squeue`, `sacct`, `scancel`) for manual inspection or
+  cancellation; the automation prints job IDs in the log.
+- To add more datasets or ablations, append new entries to `datasets` or
+  `experiments`; outputs will continue to mirror the DUQGEN directory tree.
+
+With the configuration in place, typing your password once is enough to launch
+MOE question generation, DUQGEN evaluation, and result aggregation end-to-end.
+
+## 快速上手（中文）
+
+如果你希望直接在 Codespaces（或本地机器）里一次性完成所有 DUQGEN + MOE 的实验，按照下面的步骤操作即可：
+
+1. **安装本地依赖**：
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **检查配置文件**：打开 `configs/duqgen_moe.yaml`，根据你的服务器环境修改：
+   - `env.workdir`：服务器上 DUQGEN 仓库的绝对路径；脚本会自动进入该目录，保证目录结构不被破坏。
+   - `env.setup`：例如 `source ~/.bashrc && conda activate duqgen`，保证后续命令在正确的 Conda 环境中执行。
+   - `env.bootstrap`：首次运行时需要下载模型/数据集（LLaMA、Contriever、ColBERT、BEIR/NQ/FiQA 等）可在这里写好命令，脚本会自动通过 `submit` 提交一次性执行。
+   - `datasets`：把 FiQA、NQ、BEIR 数据集在服务器上的实际路径填进去。
+   - `experiments`：默认已经列出基线和 A1–A5 消融，不需要改动即可覆盖论文里的所有实验。
+
+3. **一键启动**：在 Codespaces 里运行下列命令，按提示输入服务器密码即可：
+
+   ```bash
+   python scripts/run_remote_experiments.py \
+     --config configs/duqgen_moe.yaml \
+     --host <登录节点 IP 或主机名> \
+     --user <服务器用户名> \
+     --password <服务器密码>
+   ```
+
+4. **等待自动化完成**：脚本会顺序完成以下操作，无需手动干预：
+   - （可选）执行 `env.bootstrap` 中的下载脚本，只运行一次。
+   - 针对每个数据集、每种实验（基线 + A1–A5）生成 job 脚本，调用 `submit` 提交，并轮询 `squeue/sacct` 等待完成。
+   - 自动记录 `/usr/bin/time -v`，保存 stdout/stderr、权重轨迹、聚类统计、生成的 query、评估指标。
+   - 将所有产物下载到本地 `artifacts/<dataset>/<experiment>/` 目录，并自动绘制权重/聚类热力图。
+   - 汇总为 `artifacts/summary.csv` 与 `artifacts/summary.md`，里面包含选 K 时间/显存、平均 r1、唯一率、覆盖率、nDCG@10/MAP/MRR。
+
+5. **查看结果**：所有日志、图表和指标都已经整理好，只需要打开 `artifacts/` 下的文件即可撰写报告。
+
+> 小贴士：如果服务器需要跳板机或多重 SSH，可以把 `--host` 设置为最终可达的登录节点；如需自定义端口、密钥登录等参数，可在 `python scripts/run_remote_experiments.py --help` 中查看更多选项。

--- a/configs/duqgen_moe.yaml
+++ b/configs/duqgen_moe.yaml
@@ -1,0 +1,291 @@
+# HPC-ready configuration for running MOE-DUQGEN experiments remotely.
+# Update dataset paths, model download commands, and evaluation scripts according
+# to your DUQGEN checkout. All paths below assume the canonical DUQGEN layout.
+
+env:
+  workdir: /home/<user>/DUQGEN
+  setup:
+    - source ~/.bashrc
+    - conda activate duqgen
+  bootstrap:
+    # Install DUQGEN dependencies and cache generators/datasets once per run.
+    - pip install -r requirements.txt
+    - huggingface-cli download meta-llama/Llama-2-7b-chat-hf --local-dir {workdir}/models/llama2 --local-dir-use-symlinks False
+    - huggingface-cli download facebook/contriever-msmarco --local-dir {workdir}/models/contriever --local-dir-use-symlinks False
+    - huggingface-cli download colbert-ir/colbertv2.0 --local-dir {workdir}/models/colbertv2 --local-dir-use-symlinks False
+    - mkdir -p {workdir}/data/beir
+    - python -c "from beir import util; [util.download_and_unzip(ds, '{workdir}/data/beir') for ds in ['fiqa','nfcorpus','scifact','trec-covid']]"
+  submit:
+    binary: submit
+    env: duqgen
+    job_dir: runtime/moe_jobs
+    poll_interval: 60
+    extra_args:
+      - -p
+      - gpu-test
+
+# Datasets from the DUQGEN paper (BEIR + FiQA/NQ). Replace the paths with the
+# actual locations of the prepared collections and retrieval runs on the server.
+datasets:
+  - name: fiqa
+    collection_jsonl: /home/<user>/DUQGEN/data/beir/fiqa/collection.jsonl
+    collection_emb_pt: /home/<user>/DUQGEN/data/beir/fiqa/collection.pt
+    eval_run: /home/<user>/DUQGEN/runs/beir/fiqa
+  - name: nfcorpus
+    collection_jsonl: /home/<user>/DUQGEN/data/beir/nfcorpus/collection.jsonl
+    collection_emb_pt: /home/<user>/DUQGEN/data/beir/nfcorpus/collection.pt
+    eval_run: /home/<user>/DUQGEN/runs/beir/nfcorpus
+  - name: scifact
+    collection_jsonl: /home/<user>/DUQGEN/data/beir/scifact/collection.jsonl
+    collection_emb_pt: /home/<user>/DUQGEN/data/beir/scifact/collection.pt
+    eval_run: /home/<user>/DUQGEN/runs/beir/scifact
+  - name: trec-covid
+    collection_jsonl: /home/<user>/DUQGEN/data/beir/trec-covid/collection.jsonl
+    collection_emb_pt: /home/<user>/DUQGEN/data/beir/trec-covid/collection.pt
+    eval_run: /home/<user>/DUQGEN/runs/beir/trec-covid
+  - name: nq
+    collection_jsonl: /home/<user>/DUQGEN/data/duqgen/nq/collection.jsonl
+    collection_emb_pt: /home/<user>/DUQGEN/data/duqgen/nq/collection.pt
+    eval_run: /home/<user>/DUQGEN/runs/duqgen/nq
+
+# Experiments illustrating ablations A1–A5. Command templates run from
+# ``env.workdir`` on the remote host and inherit the DUQGEN layout.
+experiments:
+  - id: moe_full
+    description: Full MOE-DUQGEN++ pipeline
+    params:
+      target_num_q: 1000
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --use_dedup --n_cands 5
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a1_subsample
+    description: Auto-K selection using subsampling baseline
+    params:
+      target_num_q: 1000
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --use_dedup --n_cands 5 --auto_k_subsample
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a2_drop_neighbor
+    description: Remove neighbor density expert
+    params:
+      target_num_q: 1000
+      disable_expert: neighbor
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --use_dedup --n_cands 5 --disable_expert {disable_expert}
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a2_drop_tfidf
+    description: Remove TF-IDF salience expert
+    params:
+      target_num_q: 1000
+      disable_expert: tfidf
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --use_dedup --n_cands 5 --disable_expert {disable_expert}
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a2_drop_ni
+    description: Remove novelty/exclusivity expert
+    params:
+      target_num_q: 1000
+      disable_expert: novelty
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --use_dedup --n_cands 5 --disable_expert {disable_expert}
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a2_drop_cluster
+    description: Remove cluster distance expert
+    params:
+      target_num_q: 1000
+      disable_expert: cluster
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --use_dedup --n_cands 5 --disable_expert {disable_expert}
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a3_reward_r1
+    description: Enable only r1 reward
+    params:
+      target_num_q: 1000
+      reward_mask: r1
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --use_dedup --n_cands 5 --reward_mask {reward_mask}
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a3_reward_r12
+    description: Enable r1 + r2 rewards
+    params:
+      target_num_q: 1000
+      reward_mask: r1,r2
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --use_dedup --n_cands 5 --reward_mask {reward_mask}
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a3_reward_r123
+    description: Enable r1 + r2 + r3 rewards
+    params:
+      target_num_q: 1000
+      reward_mask: r1,r2,r3
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --use_dedup --n_cands 5 --reward_mask {reward_mask}
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a4_no_anticollapse
+    description: Disable weight floor + entropy regularisation
+    params:
+      target_num_q: 1000
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --n_cands 5 --no_use_floor --no_use_entropy
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json
+  - id: ablation_a5_candidate_only
+    description: Candidate sampling without deduplication
+    params:
+      target_num_q: 1000
+    generation:
+      command: >-
+        python scripts/moe_duqgen.py --collection_jsonl {collection_jsonl}
+        --collection_emb_pt {collection_emb_pt} --out_dir {output_dir}
+        --cache_dir cache --auto_k --align_to_k --use_candidate_best
+        --n_cands 5 --no_use_dedup
+      measure_time: true
+      artifacts:
+        - {output_dir}/generated_queries.jsonl
+        - {output_dir}/weights_history.jsonl
+        - {output_dir}/cluster_stats.json
+    evaluation:
+      - command: >-
+          python scripts/evaluate_duqgen.py --dataset {name}
+          --queries {output_dir}/generated_queries.jsonl
+          --runs {eval_run} --output {output_dir}/metrics.json
+        metrics_file: {output_dir}/metrics.json

--- a/moe_qgen/__init__.py
+++ b/moe_qgen/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for orchestrating MOE-DUQGEN experiments."""
+
+from .metrics import load_metrics_files, aggregate_metrics
+from .plots import plot_weight_heatmap, plot_cluster_heatmap
+from .remote import RemoteRunner, CommandResult
+from .utils import parse_time_output, ensure_local_dir
+
+__all__ = [
+    "RemoteRunner",
+    "CommandResult",
+    "load_metrics_files",
+    "aggregate_metrics",
+    "plot_weight_heatmap",
+    "plot_cluster_heatmap",
+    "parse_time_output",
+    "ensure_local_dir",
+]

--- a/moe_qgen/metrics.py
+++ b/moe_qgen/metrics.py
@@ -1,0 +1,60 @@
+"""Metric aggregation helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional
+
+import pandas as pd
+
+
+@dataclass
+class MetricsSummary:
+    dataset: str
+    experiment: str
+    select_k_time: float | None = None
+    select_k_memory: float | None = None
+    avg_r1: float | None = None
+    uniqueness: float | None = None
+    coverage: float | None = None
+    ndcg10: float | None = None
+    map: float | None = None
+    mrr: float | None = None
+    extras: Dict[str, float | None] = field(default_factory=dict)
+
+    def to_row(self) -> Dict[str, float | None]:
+        base = {
+            "dataset": self.dataset,
+            "experiment": self.experiment,
+            "select_k_time": self.select_k_time,
+            "select_k_memory": self.select_k_memory,
+            "avg_r1": self.avg_r1,
+            "uniqueness": self.uniqueness,
+            "coverage": self.coverage,
+            "ndcg@10": self.ndcg10,
+            "map": self.map,
+            "mrr": self.mrr,
+        }
+        base.update(self.extras)
+        return base
+
+
+def load_metrics_files(paths: Iterable[str]) -> Dict[str, float]:
+    aggregated: Dict[str, float] = {}
+    for path in paths:
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"Metrics file not found: {p}")
+        with p.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, Mapping):
+            raise ValueError(f"Metrics file must contain a JSON object: {p}")
+        aggregated.update({k: float(v) for k, v in data.items() if isinstance(v, (int, float))})
+    return aggregated
+
+
+def aggregate_metrics(summaries: Iterable[MetricsSummary]) -> pd.DataFrame:
+    rows = [summary.to_row() for summary in summaries]
+    return pd.DataFrame(rows)

--- a/moe_qgen/plots.py
+++ b/moe_qgen/plots.py
@@ -1,0 +1,67 @@
+"""Plotting utilities for MOE-DUQGEN artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+sns.set_theme(style="whitegrid")
+
+
+def _load_weights_history(path: str | Path) -> pd.DataFrame:
+    path = Path(path)
+    records = []
+    if not path.exists():
+        raise FileNotFoundError(f"weights_history.jsonl not found: {path}")
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            records.append(json.loads(line))
+    df = pd.DataFrame(records)
+    if df.empty:
+        raise ValueError(f"No records found in {path}")
+    weights = pd.DataFrame(df["weights"].tolist(), columns=["expert_1", "expert_2", "expert_3", "expert_4"])
+    weights["step"] = df["step"].values
+    weights["cid"] = df["cid"].values
+    return weights
+
+
+def plot_weight_heatmap(history_path: str | Path, output_path: str | Path) -> None:
+    df = _load_weights_history(history_path)
+    weight_matrix = df.set_index("step")[['expert_1', 'expert_2', 'expert_3', 'expert_4']]
+    plt.figure(figsize=(10, 4))
+    sns.heatmap(weight_matrix.T, cmap="mako", cbar_kws={"label": "Weight"})
+    plt.xlabel("Generation step")
+    plt.ylabel("Expert")
+    plt.title("Expert weight evolution")
+    plt.tight_layout()
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(output_path, dpi=200)
+    plt.close()
+
+
+def plot_cluster_heatmap(history_path: str | Path, cluster_count: int, output_path: str | Path, max_steps: int = 200) -> None:
+    df = _load_weights_history(history_path)
+    steps = min(max_steps, len(df))
+    matrix = np.zeros((cluster_count, steps), dtype=float)
+    for idx, cid in enumerate(df["cid"].values[:steps]):
+        matrix[int(cid), idx] = 1.0
+    plt.figure(figsize=(12, max(4, cluster_count / 10)))
+    sns.heatmap(matrix, cmap="crest", cbar=False)
+    plt.xlabel("Generation step")
+    plt.ylabel("Cluster id")
+    plt.title("Cluster visitations (first %s steps)" % steps)
+    plt.tight_layout()
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(output_path, dpi=200)
+    plt.close()

--- a/moe_qgen/remote.py
+++ b/moe_qgen/remote.py
@@ -1,0 +1,173 @@
+"""SSH helper utilities for orchestrating remote experiments."""
+
+from __future__ import annotations
+
+import dataclasses
+import getpass
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+import paramiko
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CommandResult:
+    """Result of a remote command execution."""
+
+    command: str
+    return_code: int
+    stdout: str
+    stderr: str
+    start_time: float
+    end_time: float
+
+    @property
+    def duration(self) -> float:
+        return self.end_time - self.start_time
+
+
+class RemoteRunner:
+    """Thin wrapper around :mod:`paramiko` to run commands sequentially."""
+
+    def __init__(
+        self,
+        host: str,
+        user: str,
+        password: Optional[str] = None,
+        port: int = 22,
+        connect_timeout: int = 30,
+        compress: bool = True,
+    ) -> None:
+        self.host = host
+        self.user = user
+        self.password = password
+        self.port = port
+        self.connect_timeout = connect_timeout
+        self.compress = compress
+        self._client: Optional[paramiko.SSHClient] = None
+        self._sftp: Optional[paramiko.SFTPClient] = None
+
+    def __enter__(self) -> "RemoteRunner":
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def connect(self) -> None:
+        if self._client is not None:
+            return
+        password = self.password or getpass.getpass(prompt=f"Password for {self.user}@{self.host}: ")
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        logger.debug("Connecting to %s:%s", self.host, self.port)
+        client.connect(
+            hostname=self.host,
+            port=self.port,
+            username=self.user,
+            password=password,
+            timeout=self.connect_timeout,
+            compress=self.compress,
+        )
+        self._client = client
+        self._sftp = client.open_sftp()
+
+    @property
+    def client(self) -> paramiko.SSHClient:
+        if self._client is None:
+            raise RuntimeError("RemoteRunner has not been connected yet")
+        return self._client
+
+    @property
+    def sftp(self) -> paramiko.SFTPClient:
+        if self._sftp is None:
+            raise RuntimeError("SFTP session has not been established")
+        return self._sftp
+
+    def close(self) -> None:
+        if self._sftp is not None:
+            self._sftp.close()
+            self._sftp = None
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def run(self, command: str, env: Optional[Sequence[str]] = None) -> CommandResult:
+        """Execute ``command`` remotely and capture stdout/stderr."""
+
+        if env:
+            command = " && ".join(list(env) + [command])
+        full_cmd = f"bash -lc '{command}'"
+        logger.info("Executing on %s: %s", self.host, full_cmd)
+        stdin, stdout, stderr = self.client.exec_command(full_cmd)
+        start = time.time()
+        stdout_data = stdout.read().decode("utf-8", errors="replace")
+        stderr_data = stderr.read().decode("utf-8", errors="replace")
+        return_code = stdout.channel.recv_exit_status()
+        end = time.time()
+        logger.debug("Command finished with code %s", return_code)
+        return CommandResult(
+            command=full_cmd,
+            return_code=return_code,
+            stdout=stdout_data,
+            stderr=stderr_data,
+            start_time=start,
+            end_time=end,
+        )
+
+    def download(self, remote_path: str, local_path: str) -> None:
+        logger.info("Downloading %s -> %s", remote_path, local_path)
+        self.sftp.get(remote_path, local_path)
+
+    def upload(self, local_path: str, remote_path: str) -> None:
+        logger.info("Uploading %s -> %s", local_path, remote_path)
+        self.sftp.put(local_path, remote_path)
+
+    def write_text(self, remote_path: str, content: str, mode: int = 0o644) -> None:
+        """Write ``content`` to ``remote_path`` using UTF-8 encoding."""
+
+        directory = str(Path(remote_path).parent)
+        if directory not in {"", "."}:
+            self.ensure_remote_dirs([directory])
+        logger.debug("Writing remote file %s", remote_path)
+        with self.sftp.open(remote_path, "w") as remote_file:
+            remote_file.write(content.encode("utf-8"))
+        self.sftp.chmod(remote_path, mode)
+
+    def read_text(self, remote_path: str) -> str:
+        logger.debug("Reading remote file %s", remote_path)
+        with self.sftp.open(remote_path, "r") as remote_file:
+            return remote_file.read().decode("utf-8", errors="replace")
+
+    def exists(self, remote_path: str) -> bool:
+        try:
+            self.sftp.stat(remote_path)
+            return True
+        except FileNotFoundError:
+            return False
+
+    def ensure_remote_dirs(self, paths: Iterable[str]) -> None:
+        for path in paths:
+            self._ensure_remote_dir(path)
+
+    def _ensure_remote_dir(self, path: str) -> None:
+        directories: List[str] = []
+        current = ""
+        for component in path.strip("/").split("/"):
+            current = f"{current}/{component}" if current else f"/{component}"
+            directories.append(current)
+        for directory in directories:
+            try:
+                self.sftp.stat(directory)
+            except FileNotFoundError:
+                logger.debug("Creating remote directory %s", directory)
+                self.sftp.mkdir(directory)
+
+
+def command_result_to_dict(result: CommandResult) -> dict:
+    return dataclasses.asdict(result)

--- a/moe_qgen/utils.py
+++ b/moe_qgen/utils.py
@@ -1,0 +1,87 @@
+"""Utility helpers for MOE-DUQGEN automation."""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+_TIME_PATTERN = re.compile(r"Elapsed \(wall clock\) time \((?:h:mm:ss|seconds)\) : (?P<value>.+)")
+_MEM_PATTERN = re.compile(r"Maximum resident set size \(kbytes\): (?P<value>\d+)")
+
+
+def ensure_local_dir(path: str | os.PathLike) -> Path:
+    """Ensure that ``path`` exists locally and return a :class:`Path` instance."""
+
+    path_obj = Path(path)
+    path_obj.mkdir(parents=True, exist_ok=True)
+    return path_obj
+
+
+@dataclass
+class TimeUsage:
+    """Container describing execution time and memory usage."""
+
+    seconds: float | None
+    max_rss_mb: float | None
+
+    def as_dict(self) -> Dict[str, float | None]:
+        return {"select_k_time": self.seconds, "select_k_memory": self.max_rss_mb}
+
+
+def _parse_wall_clock(value: str) -> float | None:
+    """Parse the wall clock value emitted by ``/usr/bin/time -v``."""
+
+    value = value.strip()
+    if not value:
+        return None
+    if value.isdigit():
+        return float(value)
+    if value.count(":") == 2:
+        hours, minutes, seconds = value.split(":")
+        return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+    if value.count(":") == 1:
+        minutes, seconds = value.split(":")
+        return int(minutes) * 60 + float(seconds)
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def parse_time_output(text: str) -> TimeUsage:
+    """Parse ``/usr/bin/time -v`` stderr text.
+
+    Parameters
+    ----------
+    text:
+        Raw stderr captured from the command.
+    """
+
+    seconds = None
+    max_rss_mb = None
+    for line in text.splitlines():
+        m_time = _TIME_PATTERN.search(line)
+        if m_time:
+            seconds = _parse_wall_clock(m_time.group("value"))
+            continue
+        m_mem = _MEM_PATTERN.search(line)
+        if m_mem:
+            max_rss_mb = int(m_mem.group("value")) / 1024.0
+    return TimeUsage(seconds=seconds, max_rss_mb=max_rss_mb)
+
+
+def apply_template(template: str, context: Dict[str, str]) -> str:
+    """Apply a basic ``str.format`` template with safe substitution."""
+
+    try:
+        return template.format(**context)
+    except KeyError as exc:  # pragma: no cover - user error surfaced clearly
+        missing = exc.args[0]
+        raise KeyError(f"Missing placeholder '{missing}' in context for template: {template}") from exc
+
+
+def apply_templates(templates: Iterable[str], context: Dict[str, str]) -> Tuple[str, ...]:
+    return tuple(apply_template(t, context) for t in templates)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+matplotlib>=3.8.0
+pandas>=2.1.0
+paramiko>=3.3.1
+PyYAML>=6.0.1
+seaborn>=0.12.2
+tabulate>=0.9.0

--- a/scripts/run_remote_experiments.py
+++ b/scripts/run_remote_experiments.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python
+"""Run MOE-DUQGEN experiments remotely and aggregate the metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import shlex
+import time
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import yaml
+
+from moe_qgen import (
+    CommandResult,
+    RemoteRunner,
+    aggregate_metrics,
+    ensure_local_dir,
+    load_metrics_files,
+    parse_time_output,
+    plot_cluster_heatmap,
+    plot_weight_heatmap,
+)
+from moe_qgen.metrics import MetricsSummary
+
+logger = logging.getLogger("moe_qgen.runner")
+
+
+@dataclass
+class SubmitConfig:
+    """Configuration for the cluster ``submit`` wrapper."""
+
+    binary: str = "submit"
+    poll_interval: int = 60
+    job_dir: str = ".moe_jobs"
+    extra_args: List[str] = field(default_factory=list)
+    env: Optional[str] = None
+    max_name_length: int = 80
+
+
+_JOB_ID_RE = re.compile(r"(\d+)")
+_JOB_NAME_SANITIZE = re.compile(r"[^A-Za-z0-9_-]+")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True, help="YAML configuration file")
+    parser.add_argument("--host", required=True)
+    parser.add_argument("--user", required=True)
+    parser.add_argument("--password", help="Server password. If omitted, a prompt will be shown.")
+    parser.add_argument("--port", type=int, default=22)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts"),
+        help="Local directory to store downloaded artifacts.",
+    )
+    parser.add_argument("--log-level", default="INFO")
+    return parser.parse_args()
+
+
+def load_config(path: Path) -> Dict:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def build_env_commands(setup: Iterable[str], workdir: str) -> List[str]:
+    commands = list(setup or [])
+    commands.append(f"cd {workdir}")
+    return commands
+
+
+def parse_submit_config(config: Optional[Dict]) -> Optional[SubmitConfig]:
+    if not config:
+        return None
+    return SubmitConfig(
+        binary=config.get("binary", "submit"),
+        poll_interval=int(config.get("poll_interval", 60)),
+        job_dir=config.get("job_dir", ".moe_jobs"),
+        extra_args=list(config.get("extra_args", [])),
+        env=config.get("env"),
+        max_name_length=int(config.get("max_name_length", 80)),
+    )
+
+
+def resolve_remote_path(path: str, workdir: str) -> str:
+    pure = PurePosixPath(path)
+    if pure.is_absolute():
+        return str(pure)
+    return str(PurePosixPath(workdir) / pure)
+
+
+def relative_to_workdir(path: str, workdir: str) -> str:
+    try:
+        return str(PurePosixPath(path).relative_to(PurePosixPath(workdir)))
+    except ValueError:
+        return path
+
+
+def sanitise_job_name(name: str, max_length: int) -> str:
+    cleaned = _JOB_NAME_SANITIZE.sub("-", name).strip("-")
+    if not cleaned:
+        cleaned = "moe-job"
+    if len(cleaned) > max_length:
+        cleaned = cleaned[:max_length]
+    return cleaned
+
+
+def extract_job_id(text: str) -> Optional[str]:
+    matches = _JOB_ID_RE.findall(text)
+    return matches[-1] if matches else None
+
+
+def parse_exit_code(exit_code: str, state: str) -> int:
+    primary = exit_code.split(":", 1)[0] if exit_code else "0"
+    rc = int(primary) if primary.isdigit() else 0
+    if state and state.upper() not in {"COMPLETED", "COMPLET"} and rc == 0:
+        rc = 1
+    return rc
+
+
+def wait_for_job_completion(runner: RemoteRunner, job_id: str, poll_interval: int) -> None:
+    logger.info("Waiting for job %s", job_id)
+    while True:
+        status = runner.run(f"squeue -h -j {job_id}")
+        if status.return_code != 0 or not status.stdout.strip():
+            break
+        time.sleep(poll_interval)
+
+
+def query_job_state(runner: RemoteRunner, job_id: str) -> Tuple[str, str]:
+    status = runner.run(f"sacct -P -b -j {job_id} -o State,ExitCode")
+    if status.return_code != 0:
+        return "UNKNOWN", "0:0"
+    lines = [line for line in status.stdout.splitlines() if line and not line.startswith("State")]
+    if not lines:
+        return "UNKNOWN", "0:0"
+    parts = lines[-1].split("|")
+    state = parts[0].strip()
+    exit_code = parts[1].strip() if len(parts) > 1 else "0:0"
+    return state, exit_code
+
+
+def execute_via_submit(
+    runner: RemoteRunner,
+    *,
+    command: str,
+    env_commands: Sequence[str],
+    submit_cfg: SubmitConfig,
+    workdir: str,
+    job_prefix: str,
+    remote_output_dir: str,
+    capture_time: bool,
+) -> Tuple[CommandResult, Optional[str], Dict[str, str]]:
+    job_root = resolve_remote_path(submit_cfg.job_dir, workdir)
+    runner.ensure_remote_dirs([job_root, remote_output_dir])
+    job_name = sanitise_job_name(job_prefix, submit_cfg.max_name_length)
+    script_path = str(PurePosixPath(job_root) / f"{job_name}.sh")
+    job_stdout = str(PurePosixPath(job_root) / f"{job_name}.out")
+    job_stderr = str(PurePosixPath(job_root) / f"{job_name}.err")
+    time_log = (
+        str(PurePosixPath(remote_output_dir) / f"{job_name}.time") if capture_time else None
+    )
+
+    script_lines = ["#!/bin/bash", "set -euo pipefail"]
+    script_lines.extend(env_commands)
+    script_lines.append(f"mkdir -p {shlex.quote(remote_output_dir)}")
+    if capture_time and time_log:
+        script_lines.append(f"/usr/bin/time -v -o {shlex.quote(time_log)} {command}")
+    else:
+        script_lines.append(command)
+    script_content = "\n".join(script_lines) + "\n"
+    runner.write_text(script_path, script_content, mode=0o755)
+
+    submit_parts: List[str] = [submit_cfg.binary, "-j", job_name, "-o", job_stdout, "-e", job_stderr]
+    if submit_cfg.env:
+        submit_parts.extend(["-env", submit_cfg.env])
+    submit_parts.extend(submit_cfg.extra_args)
+    submit_parts.extend(["--", "bash", script_path])
+    submit_command = " ".join(shlex.quote(part) for part in submit_parts)
+
+    submit_result = runner.run(submit_command)
+    if submit_result.return_code != 0:
+        raise RuntimeError(
+            f"Failed to submit job '{job_name}': {submit_result.stderr or submit_result.stdout}"
+        )
+    job_id = extract_job_id(submit_result.stdout + submit_result.stderr)
+    if not job_id:
+        raise RuntimeError(f"Unable to determine job id for submission '{job_name}'.")
+
+    start = time.time()
+    wait_for_job_completion(runner, job_id, submit_cfg.poll_interval)
+    end = time.time()
+    state, exit_code = query_job_state(runner, job_id)
+    rc = parse_exit_code(exit_code, state)
+
+    stdout_text = runner.read_text(job_stdout) if runner.exists(job_stdout) else ""
+    stderr_text = runner.read_text(job_stderr) if runner.exists(job_stderr) else ""
+    time_text = runner.read_text(time_log) if capture_time and time_log and runner.exists(time_log) else None
+
+    result = CommandResult(
+        command=command,
+        return_code=rc,
+        stdout=stdout_text,
+        stderr=stderr_text,
+        start_time=start,
+        end_time=end,
+    )
+
+    meta = {
+        "job_id": job_id,
+        "job_name": job_name,
+        "job_stdout": job_stdout,
+        "job_stderr": job_stderr,
+        "time_log": time_log,
+        "state": state,
+        "exit_code": exit_code,
+        "script_path": script_path,
+    }
+    logger.info("Job %s finished with state=%s exit=%s", job_id, state, exit_code)
+    return result, time_text, meta
+
+
+def execute_command(
+    runner: RemoteRunner,
+    *,
+    command: str,
+    env_commands: Sequence[str],
+    submit_cfg: Optional[SubmitConfig],
+    workdir: str,
+    job_prefix: str,
+    remote_output_dir: str,
+    capture_time: bool,
+) -> Tuple[CommandResult, Optional[str], Dict[str, str]]:
+    if submit_cfg:
+        return execute_via_submit(
+            runner,
+            command=command,
+            env_commands=env_commands,
+            submit_cfg=submit_cfg,
+            workdir=workdir,
+            job_prefix=job_prefix,
+            remote_output_dir=remote_output_dir,
+            capture_time=capture_time,
+        )
+    formatted_command = f"/usr/bin/time -v {command}" if capture_time else command
+    result = runner.run(formatted_command, env=env_commands)
+    time_text = result.stderr if capture_time else None
+    meta = {
+        "job_id": None,
+        "job_name": job_prefix,
+        "job_stdout": None,
+        "job_stderr": None,
+        "time_log": None,
+        "state": "DIRECT",
+        "exit_code": str(result.return_code),
+        "script_path": None,
+    }
+    return result, time_text, meta
+
+
+def ensure_remote_paths(runner: RemoteRunner, paths: Iterable[str]) -> None:
+    for path in paths:
+        if path:
+            runner.ensure_remote_dirs([path])
+
+
+def run_bootstrap(
+    runner: RemoteRunner,
+    commands: Iterable[str],
+    env_commands: Sequence[str],
+    submit_cfg: Optional[SubmitConfig],
+    workdir: str,
+) -> None:
+    for idx, raw_cmd in enumerate(commands, start=1):
+        command = raw_cmd.format(workdir=workdir)
+        logger.info("[bootstrap %d] %s", idx, command)
+        result, _, meta = execute_command(
+            runner,
+            command=command,
+            env_commands=env_commands,
+            submit_cfg=submit_cfg,
+            workdir=workdir,
+            job_prefix=f"bootstrap-{idx}",
+            remote_output_dir=resolve_remote_path(submit_cfg.job_dir if submit_cfg else workdir, workdir),
+            capture_time=False,
+        )
+        if result.return_code != 0:
+            raise RuntimeError(
+                f"Bootstrap command failed (job {meta.get('job_id') or 'direct'}): {result.stderr}"
+            )
+
+
+def run_experiment(
+    runner: RemoteRunner,
+    dataset: Dict,
+    experiment: Dict,
+    env_commands: Sequence[str],
+    output_base: Path,
+    workdir: str,
+    submit_cfg: Optional[SubmitConfig],
+) -> MetricsSummary:
+    dataset_name = dataset["name"]
+    experiment_id = experiment["id"]
+    logger.info("=== Dataset: %s | Experiment: %s ===", dataset_name, experiment_id)
+
+    remote_output_rel = experiment.get("remote_output", f"runs/{dataset_name}/{experiment_id}")
+    remote_output_dir = resolve_remote_path(remote_output_rel, workdir)
+    ensure_remote_paths(runner, [remote_output_dir])
+
+    context = {
+        **dataset,
+        **experiment.get("params", {}),
+        "output_dir": remote_output_dir,
+        "output_dir_rel": relative_to_workdir(remote_output_dir, workdir),
+        "workdir": workdir,
+    }
+
+    generation_cfg = experiment["generation"]
+    measure_time = generation_cfg.get("measure_time", True)
+    generation_cmd = generation_cfg["command"].format(**context)
+    gen_result, time_text, gen_meta = execute_command(
+        runner,
+        command=generation_cmd,
+        env_commands=env_commands,
+        submit_cfg=submit_cfg,
+        workdir=workdir,
+        job_prefix=f"{dataset_name}-{experiment_id}-gen",
+        remote_output_dir=remote_output_dir,
+        capture_time=measure_time,
+    )
+    if gen_result.return_code != 0:
+        raise RuntimeError(
+            f"Generation command failed for {dataset_name}/{experiment_id}: {gen_result.stderr}"
+        )
+    time_info = parse_time_output(time_text) if time_text else None
+
+    local_exp_dir = ensure_local_dir(output_base / dataset_name / experiment_id)
+
+    artifact_templates = list(dict.fromkeys(generation_cfg.get("artifacts", [])))
+    extra_artifacts: List[str] = []
+    for key in ("job_stdout", "job_stderr", "time_log"):
+        value = gen_meta.get(key)
+        if value:
+            extra_artifacts.append(value)
+
+    for artifact in artifact_templates:
+        remote_path = artifact.format(**context)
+        local_path = local_exp_dir / Path(remote_path).name
+        if runner.exists(remote_path):
+            runner.download(remote_path, str(local_path))
+        else:
+            logger.warning("Remote artifact not found: %s", remote_path)
+
+    for remote_path in extra_artifacts:
+        local_path = local_exp_dir / Path(remote_path).name
+        if runner.exists(remote_path):
+            runner.download(remote_path, str(local_path))
+
+    metric_paths: List[str] = []
+    for idx, eval_cfg in enumerate(experiment.get("evaluation", []), start=1):
+        eval_cmd = eval_cfg["command"].format(**context)
+        eval_result, _, eval_meta = execute_command(
+            runner,
+            command=eval_cmd,
+            env_commands=env_commands,
+            submit_cfg=submit_cfg,
+            workdir=workdir,
+            job_prefix=f"{dataset_name}-{experiment_id}-eval{idx}",
+            remote_output_dir=remote_output_dir,
+            capture_time=False,
+        )
+        if eval_result.return_code != 0:
+            raise RuntimeError(
+                f"Evaluation command failed for {dataset_name}/{experiment_id}: {eval_result.stderr}"
+            )
+        metric_path = eval_cfg.get("metrics_file")
+        if metric_path:
+            metric_path = metric_path.format(**context)
+            metric_paths.append(metric_path)
+            remote_metric = metric_path
+            local_metric = local_exp_dir / Path(remote_metric).name
+            if runner.exists(remote_metric):
+                runner.download(remote_metric, str(local_metric))
+        # Download evaluation logs for reference if jobs were submitted
+        if submit_cfg:
+            for key in ("job_stdout", "job_stderr"):
+                path = eval_meta.get(key)
+                if path and runner.exists(path):
+                    runner.download(path, str(local_exp_dir / Path(path).name))
+
+    local_metric_files = [str(local_exp_dir / Path(p).name) for p in metric_paths]
+    metrics = load_metrics_files(local_metric_files) if local_metric_files else {}
+
+    summary = MetricsSummary(
+        dataset=dataset_name,
+        experiment=experiment_id,
+        select_k_time=time_info.seconds if time_info else None,
+        select_k_memory=time_info.max_rss_mb if time_info else None,
+        avg_r1=metrics.get("avg_r1"),
+        uniqueness=metrics.get("uniqueness"),
+        coverage=metrics.get("coverage"),
+        ndcg10=metrics.get("ndcg@10"),
+        map=metrics.get("map"),
+        mrr=metrics.get("mrr"),
+    )
+
+    if experiment.get("plots", True):
+        weight_history = local_exp_dir / "weights_history.jsonl"
+        cluster_stats_path = local_exp_dir / "cluster_stats.json"
+        if weight_history.exists():
+            plot_weight_heatmap(weight_history, local_exp_dir / "weights_heatmap.png")
+            if cluster_stats_path.exists():
+                with cluster_stats_path.open("r", encoding="utf-8") as f:
+                    stats = json.load(f)
+                cluster_count = int(stats.get("K", len(stats.get("cluster_sizes", []))))
+                plot_cluster_heatmap(
+                    weight_history,
+                    cluster_count,
+                    local_exp_dir / "cluster_heatmap.png",
+                )
+
+    return summary
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    config = load_config(args.config)
+    output_dir = ensure_local_dir(args.output_dir)
+
+    env_cfg = config.get("env", {})
+    if "workdir" not in env_cfg:
+        raise ValueError("Configuration must define env.workdir")
+    workdir = env_cfg["workdir"]
+    env_commands = build_env_commands(env_cfg.get("setup", []), workdir)
+    submit_cfg = parse_submit_config(env_cfg.get("submit"))
+
+    datasets = config.get("datasets", [])
+    experiments = config.get("experiments", [])
+    if not datasets:
+        raise ValueError("No datasets specified in the configuration")
+    if not experiments:
+        raise ValueError("No experiments specified in the configuration")
+
+    summaries: List[MetricsSummary] = []
+    with RemoteRunner(
+        host=args.host,
+        user=args.user,
+        password=args.password,
+        port=args.port,
+    ) as runner:
+        bootstrap_cmds = env_cfg.get("bootstrap", [])
+        if bootstrap_cmds:
+            run_bootstrap(runner, bootstrap_cmds, env_commands, submit_cfg, workdir)
+        for dataset in datasets:
+            for experiment in experiments:
+                summaries.append(
+                    run_experiment(
+                        runner,
+                        dataset,
+                        experiment,
+                        env_commands,
+                        output_dir,
+                        workdir,
+                        submit_cfg,
+                    )
+                )
+
+    df = aggregate_metrics(summaries)
+    table_path = output_dir / "summary.csv"
+    df.to_csv(table_path, index=False)
+    markdown_path = output_dir / "summary.md"
+    df.to_markdown(markdown_path, index=False)
+    logger.info("Summary saved to %s and %s", table_path, markdown_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Chinese quick-start section that explains the end-to-end DUQGEN + MOE automation flow for Codespaces users
- document configuration checks, the single command to run, and how artifacts are gathered automatically

## Testing
- python -m compileall moe_qgen scripts/run_remote_experiments.py

------
https://chatgpt.com/codex/tasks/task_e_68e47f532078832faca3f4c138eee959